### PR TITLE
Fix compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ time  = "0.1.16"
 bytes = "0.1.2"
 
 [dependencies.nix]
-nix = "https://github.com/carllerche/nix-rust"
+git = "https://github.com/carllerche/nix-rust"
 
 [dev-dependencies]
 env_logger = "0.2.2"


### PR DESCRIPTION
```
╭─mindcat@mindcat-linux-pc /tmp/mio  ‹master› 
╰─➤  cargo build                                                                                                                                                 101 ↵
   Compiling mio v0.2.1 (file:///tmp/mio)
src/os/posix.rs:240:17: 240:36 error: unresolved name `nix::SockAddr::IpV4`
src/os/posix.rs:240     let mut a = nix::SockAddr::IpV4(sa);
                                    ^~~~~~~~~~~~~~~~~~~
src/os/posix.rs:249:17: 249:36 error: unresolved name `nix::SockAddr::IpV4`
src/os/posix.rs:249     let mut a = nix::SockAddr::IpV4(sa);
                                    ^~~~~~~~~~~~~~~~~~~
src/os/posix.rs:287:9: 287:28 error: unresolved enum variant, struct or const `IpV4`
src/os/posix.rs:287         nix::SockAddr::IpV4(sin) => {
                            ^~~~~~~~~~~~~~~~~~~
src/os/posix.rs:290:9: 290:28 error: unresolved enum variant, struct or const `Unix`
src/os/posix.rs:290         nix::SockAddr::Unix(addr) => {
                            ^~~~~~~~~~~~~~~~~~~
src/os/posix.rs:316:21: 316:40 error: unresolved name `nix::SockAddr::IpV4`
src/os/posix.rs:316                     nix::SockAddr::IpV4(addr)
                                        ^~~~~~~~~~~~~~~~~~~
src/os/posix.rs:332:13: 332:32 error: unresolved name `nix::SockAddr::Unix`
src/os/posix.rs:332             nix::SockAddr::Unix(addr)
                                ^~~~~~~~~~~~~~~~~~~
error: aborting due to 6 previous errors
Could not compile `mio`.

To learn more, run the command again with --verbose.
```